### PR TITLE
Add more advance NTP settings

### DIFF
--- a/docs/fetch.md
+++ b/docs/fetch.md
@@ -6,11 +6,11 @@ Fetching or posting data to the internet is one of the core tasks of an IoT devi
 #### begin
 
 ```c++
-int begin();
-int begin(const char* tz);
-int begin(const char* tz, const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
+fetch_status_t begin();
+fetch_status_t begin(const char* tz);
+fetch_status_t begin(const char* tz, const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
 ```
-This method must be called from the setup of the application and will setup the server time needed for SSL connections and potentially useful for other parts of the application. When called without parameters the timezone is set to UTC. A list of timezone values can be found in [TZ.h](https://raw.githubusercontent.com/esp8266/Arduino/master/cores/esp8266/TZ.h). When called without specifying NTP servers 0.pool.ntp.org, 1.pool.ntp.org and 2.pool.ntp.org are used. If the time has not been set within 10s the attempt will timeout and -1 will be returned.
+This method must be called from the setup of the application and will setup the server time needed for SSL connections and potentially useful for other parts of the application. When called without parameters the timezone is set to UTC. A list of timezone values can be found in [TZ.h](https://raw.githubusercontent.com/esp8266/Arduino/master/cores/esp8266/TZ.h). When called without specifying NTP servers 0.pool.ntp.org, 1.pool.ntp.org and 2.pool.ntp.org are used. If the time has not been set within 10s the attempt will timeout and FETCH\_TIME\_NOT\_SET will be returned otherwise FETCH\_TIME\_SET will be returned.
 
 #### GET
 

--- a/docs/fetch.md
+++ b/docs/fetch.md
@@ -6,9 +6,11 @@ Fetching or posting data to the internet is one of the core tasks of an IoT devi
 #### begin
 
 ```c++
-void begin();
+int begin();
+int begin(const char* tz);
+int begin(const char* tz, const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
 ```
-This method must be called from the setup of the application and will setup the server time needed for SSL connections and potentially useful for other parts of the application.
+This method must be called from the setup of the application and will setup the server time needed for SSL connections and potentially useful for other parts of the application. When called without parameters the timezone is set to UTC. A list of timezone values can be found in [TZ.h](https://raw.githubusercontent.com/esp8266/Arduino/master/cores/esp8266/TZ.h). When called without specifying NTP servers 0.pool.ntp.org, 1.pool.ntp.org and 2.pool.ntp.org are used. If the time has not been set within 10s the attempt will timeout and -1 will be returned.
 
 #### GET
 

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -5,7 +5,7 @@
 #include <coredecls.h> // settimeofday_cb defined
 #include <PolledTimeout.h>
 
-int HTTPRequest::setTime(const char* tz, const char* server1, const char* server2, const char* server3)
+fetch_status_t HTTPRequest::setTime(const char* tz, const char* server1, const char* server2, const char* server3)
 {
     bool time_set = false;
 
@@ -18,24 +18,24 @@ int HTTPRequest::setTime(const char* tz, const char* server1, const char* server
     {
         if(time_set)
        	{
-            return 0;
+            return FETCH_TIME_SET;
         }
 	yield();
     }
-    return -1;
+    return FETCH_TIME_NOT_SET;
 }
 
-int HTTPRequest::begin()
+fetch_status_t HTTPRequest::begin()
 {
     return setTime(TZ_Etc_UTC, PSTR("0.pool.ntp.org"), PSTR("1.pool.ntp.org"), PSTR("2.pool.ntp.org"));
 }
 
-int HTTPRequest::begin(const char* tz)
+fetch_status_t HTTPRequest::begin(const char* tz)
 {
     return setTime(tz, PSTR("0.pool.ntp.org"), PSTR("1.pool.ntp.org"), PSTR("2.pool.ntp.org"));
 }
 
-int HTTPRequest::begin(const char* tz, const char* server1, const char* server2, const char* server3)
+fetch_status_t HTTPRequest::begin(const char* tz, const char* server1, const char* server2, const char* server3)
 {
     return setTime(tz, server1, server2, server3);
 }

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -5,6 +5,7 @@
 #include <ESP8266HTTPClient.h>
 
 #include "certStore.h"
+#include "fetch_definitions.h"
 
 class HTTPRequest
 {
@@ -17,9 +18,9 @@ public:
     bool available();
     uint8_t read();
     String readString();
-    int begin();
-    int begin(const char* tz);
-    int begin(const char* tz, const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
+    fetch_status_t begin();
+    fetch_status_t begin(const char* tz);
+    fetch_status_t begin(const char* tz, const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
 
 private : 
     BearSSL::CertStore certStore;
@@ -29,7 +30,7 @@ private :
     BearSSL::WiFiClientSecure *httpsClient;
 
     void beginRequest(String &url);
-    int setTime(const char* tz, const char* server1, const char* server2, const char* server3);
+    fetch_status_t setTime(const char* tz, const char* server1, const char* server2, const char* server3);
 };
 
 extern HTTPRequest fetch;

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -17,7 +17,9 @@ public:
     bool available();
     uint8_t read();
     String readString();
-    void begin();
+    int begin();
+    int begin(const char* tz);
+    int begin(const char* tz, const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
 
 private : 
     BearSSL::CertStore certStore;
@@ -27,6 +29,7 @@ private :
     BearSSL::WiFiClientSecure *httpsClient;
 
     void beginRequest(String &url);
+    int setTime(const char* tz, const char* server1, const char* server2, const char* server3);
 };
 
 extern HTTPRequest fetch;

--- a/src/fetch_definitions.h
+++ b/src/fetch_definitions.h
@@ -1,0 +1,9 @@
+#ifndef FETCH_DEFINITIONS_H_
+#define FETCH_DEFINITIONS_H_
+
+typedef enum {
+    FETCH_TIME_SET      = 0,
+    FETCH_TIME_NOT_SET  = 1,
+} fetch_status_t;
+
+#endif /* FETCH_DEFINITIONS_H_ */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include "LittleFS.h"
+#include <TZ.h>
 
 #include "WiFiManager.h"
 #include "webServer.h"
@@ -23,7 +24,7 @@ void setup()
     GUI.begin();
     configManager.begin();
     WiFiManager.begin(configManager.data.projectName);
-    fetch.begin();
+    fetch.begin(TZ_Europe_Amsterdam, "ntp.time.nl");
 }
 
 void loop() 


### PR DESCRIPTION
Updates fetch.begin so it can be called with no parameters, a timezone db entry or a timezone db entry and up to 3 NTP servers.

If called without parameters or with only a timezone db entry the 0.pool.ntp.org, 1.pool.ntp.org and 2.pool.ntp.org. If called with no parameters the timezone is set to UTC. If the time is not set within 10 seconds there is a timeout and the method returns -1.
