### PR TITLE
Public begin method

### DIFF
--- a/docs/fetch.md
+++ b/docs/fetch.md
@@ -5,40 +5,52 @@ Certificates are only valid for a specific time period; therefore, in order to d
 
 ## Class Methods
 
+#### begin
+
+```c++
+void begin(String url);
+```
+This method initializes a request object to `url`. The URL must include a http:// or https:// prefix. The method is only required if you want to use `addHeader` or `setAuthorization`. Otherwise you can use one of the shorthand request methods below.
+
 #### GET
 
 ```c++
 int GET(String url);
+int GET();
 ```
-This method starts a GET request to the URL specified in `url`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code.
+This method starts a GET request to the URL specified in `url`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code. If you first called the `begin` method, the variant without the `url` argument should be used.
 
 #### POST
 
 ```c++
 int POST(String url, String body);
+int POST(String body);
 ```
-This method starts a POST request to the URL specified in `url` with the payload specified in `body`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code.
+This method starts a POST request to the URL specified in `url` with the payload specified in `body`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code. If you first called the `begin` method, the variant without the `url` argument should be used.
 
 #### PUT
 
 ```c++
 int PUT(String url, String body);
+int PUT(String body);
 ```
-This method starts a PUT request to the URL specified in `url` with the payload specified in `body`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code.
+This method starts a PUT request to the URL specified in `url` with the payload specified in `body`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code. If you first called the `begin` method, the variant without the `url` argument should be used.
 
 #### PATCH
 
 ```c++
 int PATCH(String url, String body);
+int PATCH(String body);
 ```
-This method starts a PATCH request to the URL specified in `url` with the payload specified in `body`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code.
+This method starts a PATCH request to the URL specified in `url` with the payload specified in `body`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code. If you first called the `begin` method, the variant without the `url` argument should be used.
 
 #### DELETE
 
 ```c++
 int DELETE(String url);
+int DELETE();
 ```
-This method starts a DELETE request to the URL specified in `url`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code.
+This method starts a DELETE request to the URL specified in `url`. The URL must include a http:// or https:// prefix. The method returns the HTTP response code. If you first called the `begin` method, the variant without the `url` argument should be used.
 
 #### busy
 

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -2,7 +2,7 @@
 
 #include <WiFiClientSecureBearSSL.h>
 
-void HTTPRequest::beginRequest(String &url) 
+void HTTPRequest::begin(String url) 
 {
     http = new HTTPClient();
 
@@ -24,31 +24,56 @@ void HTTPRequest::beginRequest(String &url)
 
 int HTTPRequest::GET(String url)
 {
-    beginRequest(url);
+    begin(url);
+    return http->GET();
+}
+
+int HTTPRequest::GET()
+{
     return http->GET();
 }
 
 int HTTPRequest::POST(String url, String body)
 {
-    beginRequest(url);
+    begin(url);
+    return http->POST(body);
+}
+
+int HTTPRequest::POST(String body)
+{
     return http->POST(body);
 }
 
 int HTTPRequest::PUT(String url, String body)
 {
-    beginRequest(url);
+    begin(url);
+    return http->PUT(body);
+}
+
+int HTTPRequest::PUT(String body)
+{
     return http->PUT(body);
 }
 
 int HTTPRequest::PATCH(String url, String body)
 {
-    beginRequest(url);
+    begin(url);
+    return http->PATCH(body);
+}
+
+int HTTPRequest::PATCH(String body)
+{
     return http->PATCH(body);
 }
 
 int HTTPRequest::DELETE(String url)
 {
-    beginRequest(url);
+    begin(url);
+    return http->sendRequest("DELETE");
+}
+
+int HTTPRequest::DELETE()
+{
     return http->sendRequest("DELETE");
 }
 

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -11,15 +11,25 @@ class HTTPRequest
 
 public:
     void clean();
+
+    void begin(String url);
+
     int GET(String url);
+    int GET();
     int POST(String url, String body);
+    int POST(String body);
     int PUT(String url, String body);
+    int PUT(String body);
     int PATCH(String url, String body);
+    int PATCH(String body);
     int DELETE(String url);
+    int DELETE();
+    
     bool busy();
     bool available();
     uint8_t read();
     String readString();
+    
     void setAuthorization(const char * user, const char * password);
     void setAuthorization(const char * auth);
     void addHeader(String name, String value);
@@ -30,8 +40,6 @@ private :
     HTTPClient *http;
     WiFiClient *client;
     BearSSL::WiFiClientSecure *httpsClient;
-
-    void beginRequest(String &url);
 };
 
 extern HTTPRequest fetch;


### PR DESCRIPTION
Added new function calls to allow you to separate `http.begin` from the actual request functions. This is needed to allow you to add headers inbetween `begin` and the request, such as `GET`. 

I believe this was also required for #18 