### PR TITLE
Add Config projectName entry value to main page heading

### DIFF
--- a/html/js/index.js
+++ b/html/js/index.js
@@ -9,6 +9,8 @@ import { ConfigPage } from "./comp/ConfigPage";
 import { FilePage } from "./comp/FilePage";
 import { FirmwarePage } from "./comp/FirmwarePage";
 
+import Config from "./configuration.json";
+
 let url = "http://192.168.1.54";
 if (process.env.NODE_ENV === "production") {url = window.location.origin;}
 
@@ -17,13 +19,13 @@ if (process.env.NODE_ENV === "development") {require("preact/debug");}
 function Root() {
     
     const [menu, setMenu] = useState(false);
-
+    const projectName = Config.find(entry => entry.name === "projectName").value || "ESP8266";
     return <><GlobalStyle />
 
         <BrowserRouter>
 
             <Header>
-                <h1><Box style={{verticalAlign:"-0.1em"}} /> ESP8266</h1>
+                <h1><Box style={{verticalAlign:"-0.1em"}} /> {projectName}</h1>
 
                 <Hamburger onClick={() => setMenu(!menu)} />
                 <Menu className={menu ? "" : "menuHidden"}>


### PR DESCRIPTION
Gets the `projectName` from configuration.json and uses it for the main page heading. Helps when you have several devices/tabs open.

Might also be a good idea to set the `document.title`, to add `projectName` too.

![image](https://user-images.githubusercontent.com/7282262/96163202-80851c80-0f11-11eb-8251-fb49bacf3ed0.png)

Let me know what you think!