### PR TITLE
Install asn1crypto automatically if not present

### DIFF
--- a/scripts/preBuildCertificates.py
+++ b/scripts/preBuildCertificates.py
@@ -4,7 +4,15 @@ import os
 import re
 import string
 import sys
-from asn1crypto.x509 import Certificate
+try:
+    from asn1crypto.x509 import Certificate
+except ImportError:
+    env.Execute(
+        env.VerboseAction(
+            '$PYTHONEXE -m pip install "asn1crypto" ',
+            "ASN1 crypto import failed, installing.",
+        )
+    )
 import hashlib
 
 from subprocess import Popen, PIPE, call, check_output


### PR DESCRIPTION
In relation to #70 it would be good if the library's `extra_script` would detect if it fails to import one of not usually included python dependency and then install it via PlatformIO's specific python-pip executable.

This PR implements exactly that, analogue to the code used in an official PlatformIO platform itself (https://github.com/platformio/platform-espressif32/blob/a58a358fdc1122523c7fcf7b4fc8b4016e48961d/builder/frameworks/espidf.py#L74-L84). 