### PR TITLE
Path to openssl in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,8 @@ extra_scripts = scripts/preBuild.py
 #available build flags:
 #-DREBUILD_HTML forces a rebuild of the html.h, this is needed if you make modifications to the GUI, or the configuration or dashboard JSON files
 #-DREBUILD_CERTS forces a rebuild of the root certificate store
+#-Dopenssl="C:/Program Files/Git/usr/bin/openssl.exe" Path to openssl executable
+#-Dopenssl="C:/msys32/usr/bin/openssl" Another path to openssl executable
 #-DREBUILD_CONFIG forces a rebuild of the configuration manager cpp files based on the JSON
 #-DREBUILD_DASHBOARD forces a rebuild of the dashboard cpp files based on the JSON
 #-DDOMAIN_LIST=google.com,maakbaas.com comma separated list of domain names to limit the certificates included

--- a/scripts/preBuild.py
+++ b/scripts/preBuild.py
@@ -2,7 +2,6 @@ Import('env')
 from shutil import copyfile
 import subprocess
 import inspect, os.path
-from os.path import join, realpath
 
 #auto install asn1crypto if not defined
 try:
@@ -11,7 +10,7 @@ except ImportError:
     Import('env')
     env.Execute(
         env.VerboseAction(
-            '$PYTHONEXE -m pip install "asn1crypto" ',
+            '"$PYTHONEXE" -m pip install "asn1crypto" ',
             "ASN1 crypto import failed, installing.",
         )
     )
@@ -29,6 +28,7 @@ html = False
 config = False
 dash = False
 certs = False
+openssl = None
 
 # private library flags
 domains = ''
@@ -49,6 +49,8 @@ for item in env.get("CPPDEFINES", []):
         copyfile(env.get("PROJECT_DIR") + '/' + item[1], '../gui/js/dashboard.json')
     elif isinstance(item, tuple) and item[0] == "DOMAIN_LIST":
         domains = item[1]
+    elif isinstance(item, tuple) and item[0].lower() == "openssl":
+        openssl = item[1]
 
 if html:
     preBuildHTMLFun()
@@ -57,6 +59,6 @@ if config:
 if dash:
     preBuildDashFun()
 if certs:
-    preBuildCertificatesFun(domains)
+    preBuildCertificatesFun(domains, openssl)
 
 

--- a/scripts/preBuildCertificates.py
+++ b/scripts/preBuildCertificates.py
@@ -24,9 +24,9 @@ from ssl import wrap_socket, CERT_NONE, PROTOCOL_SSLv23
 from ssl import SSLContext  # Modern SSL?
 from ssl import HAS_SNI  # Has SNI?
 
-def preBuildCertificatesFun(domains):
+def preBuildCertificatesFun(domains, openssl):
 
-    print('Start building certificate store', flush=True) 
+    print('Start building certificate store', flush=True)
 
     allDomains = True
 
@@ -43,7 +43,8 @@ def preBuildCertificatesFun(domains):
     dir_path = os.path.dirname(os.path.abspath(filename))
 
     #path to openssl
-    openssl = "C:/msys32/usr/bin/openssl" 
+    if openssl is None:
+        openssl = "C:/Program Files/Git/usr/bin/openssl.exe"
 
     # below script content is adapted from:
     # https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266WiFi/examples/BearSSL_CertStore/certs-from-mozilla.py


### PR DESCRIPTION
platformio.ini: added path to openssl `-Dopenssl="C:/msys32/usr/bin/openssl`

Fixes #86 CLion + Pltaformio plugin uses system-wide python, `$PYTHONEXE` may contain space
