### PR TITLE
`index.js`: `Config.find` does not exist

### DIFF
--- a/gui/js/index.js
+++ b/gui/js/index.js
@@ -63,7 +63,7 @@ function Root() {
             });
     }
 
-    const projectName = configData["projectName"] || Config.find(entry => entry.name === "projectName").value || "ESP8266";
+    const projectName = configData["projectName"] || "ESP8266";
     return <><GlobalStyle />
 
         <BrowserRouter>


### PR DESCRIPTION
#88
`index.js`: `Config.find(entry => entry.name === "projectName")` throws an exception `find(...) not exists`