### PR TITLE
make serveProgmem public,  remove server.onNotFound(serveProgmem) from begin - compatibility Espalexa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+*fork of the ESP8266 IoT Framework by maakbaas with small change to allow Espalexa[https://github.com/Aircoookie/Espalexa.git] integration.*
+
+## Using the changes
+
+You can now initialise the onNotFound within your main code like below and also check if the incoming requests are for the Espalexa.
+
+```ini
+GUI.server.onNotFound([](AsyncWebServerRequest *request)
+                      {
+                        if (!espalexa.handleAlexaApiCall(request)) //if you don't know the URI, ask espalexa whether it is an Alexa control request
+                        {
+                          GUI.serveProgmem(request);
+                        }
+                      });
+```
 # ESP8266 IoT Framework ![Status](https://travis-ci.com/maakbaas/esp8266-iot-framework.svg?branch=master)
 
 The ESP8266 IoT Framework is a set of modules to be used as a starting point in new ESP8266 projects, implementing HTTPS requests, a React web interface, WiFi manager, configuration manager, live dashboard and OTA updates.

--- a/src/webServer.cpp
+++ b/src/webServer.cpp
@@ -21,7 +21,7 @@ void webServer::begin()
 
     server.serveStatic("/download", LittleFS, "/");
 
-    server.onNotFound(serveProgmem);
+    // server.onNotFound(serveProgmem);
 
     //handle uploads
     server.on(PSTR("/upload"), HTTP_POST, [](AsyncWebServerRequest *request) {}, handleFileUpload);

--- a/src/webServer.h
+++ b/src/webServer.h
@@ -8,12 +8,13 @@ class webServer
 
 private:    
     static void handleFileUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final);
-    static void serveProgmem(AsyncWebServerRequest *request);
+    // static void serveProgmem(AsyncWebServerRequest *request);
     void bindAll();
 
 public:
     AsyncWebServer server = AsyncWebServer(80);
     AsyncWebSocket ws = AsyncWebSocket("/ws");
+    static void serveProgmem(AsyncWebServerRequest *request);
     void begin();
 };
 


### PR DESCRIPTION
Hi,

Could you please take a look?

My intention is to make the serveProgrem public so when another service is also running on the same port you can handle and filter requests on your main code. 

### In the specific case of Espalexa [https://github.com/Aircoookie/Espalexa.git]:
The library offers a check to determine if the request is for the Espalexa

> server.onNotFound([](){
	if (!espalexa.handleAlexaApiCall(server.uri(),server.arg(0)))
	{
		server.send(404, "text/plain", "Not found");
	}
});

after the changes I proposed this can also be handled with esp8266-iot-framework like so:

> GUI.server.onNotFound([](AsyncWebServerRequest *request)
                                  {
                                      if (!espalexa.handleAlexaApiCall(request)) //if you don't know the URI, ask espalexa whether it is an Alexa control request
                                      {
                                          GUI.serveProgmem(request);
                                      }
                                  }); 

Take a look and see if my changes serve the purpose.

Regards,

Zenon