### PR TITLE
Add optionLabels for dropdowns

### DIFF
--- a/gui/js/comp/ControlItem.js
+++ b/gui/js/comp/ControlItem.js
@@ -97,8 +97,13 @@ export function ControlItem(props) {
         for (let i = 0; i < props.conditionalAttributes.options.length; i++) {
             if (data == props.conditionalAttributes.options[i]) {
                 isOption = true;
-            }             
-            options = <>{options}<option value={props.conditionalAttributes.options[i]}>{props.conditionalAttributes.options[i]}</option></>;            
+            }
+            let optionLabel = props.conditionalAttributes.options[i];
+            if (typeof props.conditionalAttributes.optionLabels[i] !== "undefined") {
+                optionLabel = props.conditionalAttributes.optionLabels[i];
+            }
+
+            options = <>{options}<option value={props.conditionalAttributes.options[i]}>{optionLabel}</option></>;                       
         }
 
         if (!isOption) {

--- a/gui/js/comp/DashboardItems.js
+++ b/gui/js/comp/DashboardItems.js
@@ -175,6 +175,7 @@ export function DashboardItems(props) {
 
                 case "select":
                     conditionalAttributes.options = props.items[i].options;
+                    conditionalAttributes.optionLabels = props.items[i].optionLabels;
                     break;
             }
 
@@ -213,8 +214,12 @@ export function DashboardItems(props) {
                 case "config":
                     if (inputType == "select") {
                         let options;
-                        for (let i = 0; i < conditionalAttributes.options.length; i++) {           
-                            options = <>{options}<option value={conditionalAttributes.options[i]}>{conditionalAttributes.options[i]}</option></>;            
+                        for (let i = 0; i < conditionalAttributes.options.length; i++) {  
+                            let label = conditionalAttributes.options[i];
+                            if (typeof conditionalAttributes.optionLabels[i] !== "undefined") {
+                                label = conditionalAttributes.optionLabels[i];
+                            }
+                            options = <>{options}<option value={conditionalAttributes.options[i]}>{label}</option></>;            
                         }
                         confItems = <>{confItems}
                             <p>


### PR DESCRIPTION
This PR implements the suggestion in https://github.com/maakbaas/esp8266-iot-framework/issues/100#issuecomment-863236111 - it adds an optionLabels field that is used to set differing labels and values in dropdown selectors.

While this appears to work, this is my first attempt at React, and I am unsure if this is really complete.