### PR TITLE
Update html build script subprocess.call

### DIFF
--- a/scripts/preBuildHTML.py
+++ b/scripts/preBuildHTML.py
@@ -9,9 +9,9 @@ def preBuildHTMLFun():
 
     if webpackInst == False:
         print("Running npm ci...")
-        call(["npm", "ci"], shell=True)
+        call("npm ci", shell=True)
         print("Running npx browserslist@latest --update-db...")
-        call(["npx", "browserslist@latest", "--update-db"], shell=True)
+        call("npx browserslist@latest --update-db", shell=True)
 
     print("Running npm run build...")
-    call(["npm", "run", "build"], shell=True)
+    call("npm run build", shell=True)


### PR DESCRIPTION
First off, thank you for creating this framework, it's been a ton of fun to use.

I, and a few others working on a small project together, came across this bug while trying to create some custom fields in the configuration manager page.  We were running in to a bug where the `npm` commands in the `preBuildHTML.py` script weren't getting run as intended.

We've been using PlatformIO to compile (on both Mac and Linux).  
PlatformIO: Core-5.2.3

The versions of python we've been using: 
Mac - python:3.8.2  
Linux - python:3.7.3

Below is a copy of the commit message to give more detail on the changes.  Please let me know if any more information is needed/wanted and thank you for considering this PR.

Why:

* While trying to rebuild the HTML for custom attributes, the
  preBuildHTML.py script was failing when calls were made to
  `subprocess.call`.  Under the hood the `subprocess.call` function
  calls `Popen`.  The following is from the documentation page of the
  subprocess library:

  https://docs.python.org/3/library/subprocess.html#subprocess.Popen
  ```
  If shell is True, it is recommended to pass args as a string rather than as a sequence.
  ```

  While the documentation says that passing a sequence of program
  arguments should work as intended, building on linux and Mac both
  failed when using the sequence and succeeded when using a single
  string.

This change addresses the need by:

* Updating all calls to `subprocess.call` in preBuildHTML.py to use
  single string instead of list as the first argument.