### PR TITLE
Added Callback function when start and stop Captive Portal

### DIFF
--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -193,6 +193,10 @@ void WifiManager::startCaptivePortal(char const *apName)
     Serial.println(PSTR("Opened a captive portal"));
     Serial.println(PSTR("192.168.4.1"));
     inCaptivePortal = true;
+
+    if ( _captiveportalstartcallback != NULL) {
+        _captiveportalstartcallback();
+    } 
 }
 
 //function to stop the captive portal
@@ -201,7 +205,19 @@ void WifiManager::stopCaptivePortal()
     WiFi.mode(WIFI_STA);
     delete dnsServer;
 
-    inCaptivePortal = false;    
+    inCaptivePortal = false;
+    
+    if ( _captiveportalstopcallback != NULL) {
+        _captiveportalstopcallback();
+    }    
+}
+
+void WifiManager::stoppedCaptivePortal( std::function<void()> func ) {
+  _captiveportalstopcallback = func;
+}
+
+void WifiManager::startedCaptivePortal( std::function<void()> func ) {
+  _captiveportalstartcallback = func;
 }
 
 //return captive portal state
@@ -242,3 +258,4 @@ void WifiManager::storeToEEPROM()
     configManager.internal.dns = dns.v4();
     configManager.save();
 }
+

--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -26,6 +26,8 @@ private:
     void connectNewWifi(String newSSID, String newPass);    
     void storeToEEPROM();
     int8_t waitForConnectResult(unsigned long timeoutLength);
+    std::function<void()> _captiveportalstopcallback;
+    std::function<void()> _captiveportalstartcallback;    
 
 public : 
     void begin(char const *apName, unsigned long newTimeout = 60000);
@@ -35,6 +37,9 @@ public :
     String SSID();
     void setNewWifi(String newSSID, String newPass);
     void setNewWifi(String newSSID, String newPass, String newIp, String newSub, String newGw, String newDns);
+    void stoppedCaptivePortal( std::function<void()> func );
+    void startedCaptivePortal( std::function<void()> func );
+
 };
 
 extern WifiManager WiFiManager;


### PR DESCRIPTION
I added 2 callback functions fired when captive portal start and stop. These functions are useful to execute code when captive portal start and stop in order to change device behaviour based on captive portal state.