### PR TITLE
Added 2 new functions for better new and forget WiFi Handling

### DIFF
--- a/docs/wifi-manager.md
+++ b/docs/wifi-manager.md
@@ -45,6 +45,14 @@ void setNewWifi(String newSSID, String newPass, String newIp, String newSub, Str
 ```
 Tries to connect to the WiFi network with SSID `newSSID` and password `newPass`. If this fails a reconnect to the known network will be attempted. If this also fails or if no previous network was known, a captive portal will be started. Alternatively the function can also be called with inputs for a static IP address if DHCP is not available.
 
+#### forgetWiFiFunctionCallback() and newWiFiFunctionCallback
+
+```c++
+void forgetWiFiFunctionCallback( std::function<void()> func );
+void newWiFiFunctionCallback( std::function<void()> func );
+```
+This functions is called at the end of forget WiFi or after new WiFi is configured. This would be helpful to execute your code after a WiFi configuration or after you delete a WiFi configuration from Devices
+
 ## Web interface
 
 The page in the web interface that is connected to the WiFi settings is shown below. For now this is a simple page that:

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -85,6 +85,10 @@ void WifiManager::forget()
     //make EEPROM empty
     storeToEEPROM();
 
+    if ( _forgetwificallback != NULL) {
+        _forgetwificallback();
+    } 
+
     Serial.println(PSTR("Requested to forget WiFi. Started Captive portal."));
 }
 
@@ -169,6 +173,10 @@ void WifiManager::connectNewWifi(String newSSID, String newPass)
             //store IP address in EEProm
             storeToEEPROM();
 
+            if ( _newwificallback != NULL) {
+                _newwificallback();
+            }
+
         }
     }
 }
@@ -193,6 +201,7 @@ void WifiManager::startCaptivePortal(char const *apName)
     Serial.println(PSTR("Opened a captive portal"));
     Serial.println(PSTR("192.168.4.1"));
     inCaptivePortal = true;
+
 }
 
 //function to stop the captive portal
@@ -201,7 +210,15 @@ void WifiManager::stopCaptivePortal()
     WiFi.mode(WIFI_STA);
     delete dnsServer;
 
-    inCaptivePortal = false;    
+    inCaptivePortal = false;
+}
+
+void  WifiManager::forgetWiFiFunctionCallback( std::function<void()> func ) {
+  _forgetwificallback = func;
+}
+
+void WifiManager::newWiFiFunctionCallback( std::function<void()> func ) {
+  _newwificallback = func;
 }
 
 //return captive portal state
@@ -242,3 +259,4 @@ void WifiManager::storeToEEPROM()
     configManager.internal.dns = dns.v4();
     configManager.save();
 }
+

--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -26,6 +26,8 @@ private:
     void connectNewWifi(String newSSID, String newPass);    
     void storeToEEPROM();
     int8_t waitForConnectResult(unsigned long timeoutLength);
+    std::function<void()> _forgetwificallback;
+    std::function<void()> _newwificallback;    
 
 public : 
     void begin(char const *apName, unsigned long newTimeout = 60000);
@@ -35,6 +37,8 @@ public :
     String SSID();
     void setNewWifi(String newSSID, String newPass);
     void setNewWifi(String newSSID, String newPass, String newIp, String newSub, String newGw, String newDns);
+    void forgetWiFiFunctionCallback( std::function<void()> func );
+    void newWiFiFunctionCallback( std::function<void()> func );
 };
 
 extern WifiManager WiFiManager;


### PR DESCRIPTION
In order to have better handling of device when a wifi will be forgot and when a new WiFi will be configured I added 2 new function to WiFiManager.
One is

`void forgetWiFiFunctionCallback( std::function<void()> func );`

and it will be called when a Forget WiFi procedure is completed. Other one is:

`void newWiFiFunctionCallback( std::function<void()> func );`

and it will be called when new WiFi procedure is completed.
This permit better handling on device where I need to change behaviour of the hardware if on device wifi is configured or not.

Example:

```c++
void forgetWifiCallBack();
void newWifiCallBack();

void setup()
{
    WiFiManager.begin(configManager.data.projectName);
    WiFiManager.forgetWiFiFunctionCallback(forgetWifiCallBack);
    WiFiManager.newWiFiFunctionCallback(newWifiCallBack);
}

void forgetWifiCallBack(){
    Serial.println("My Forget Wifi CallBack");
}

void newWifiCallBack(){
    Serial.println("My New Wifi CallBack");
}
```

Documentation also updated.